### PR TITLE
Use proper types for end & start time when mapping ProcessResult

### DIFF
--- a/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
+++ b/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
@@ -42,9 +42,14 @@ class ProcessResultMapper
         $processResultEntityTransfer->setSkippedItemCount($processResultTransfer->getSkippedItemCount());
         $processResultEntityTransfer->setItemCount($processResultTransfer->getItemCount());
 
-        $startTime = $processResultTransfer->getStartTime() ? date('Y-m-d H:i:s', $processResultTransfer->getStartTime()) : null;
+        $startTime = !empty($processResultTransfer->getStartTime())
+            ? date('Y-m-d H:i:s', $processResultTransfer->getStartTime())
+            : null;
         $processResultEntityTransfer->setStartTime($startTime);
-        $endTime = $processResultTransfer->getEndTime() ? date('Y-m-d H:i:s', $processResultTransfer->getEndTime()) : null;
+
+        $endTime = !empty($processResultTransfer->getEndTime())
+            ? date('Y-m-d H:i:s', $processResultTransfer->getEndTime())
+            : null;
         $processResultEntityTransfer->setEndTime($endTime);
 
         $stagesResults = $this->mapStagesResultToArray($processResultTransfer->getStageResults());
@@ -67,8 +72,14 @@ class ProcessResultMapper
         $processResultTransfer->setFailedItemCount($processResultEntityTransfer->getFailedItemCount());
         $processResultTransfer->setSkippedItemCount($processResultEntityTransfer->getSkippedItemCount());
         $processResultTransfer->setItemCount($processResultEntityTransfer->getItemCount());
-        $processResultTransfer->setStartTime(strtotime($processResultEntityTransfer->getStartTime()));
-        $processResultTransfer->setEndTime(strtotime($processResultEntityTransfer->getEndTime()));
+
+        if (!empty($processResultEntityTransfer->getStartTime())) {
+            $processResultTransfer->setStartTime(strtotime($processResultEntityTransfer->getStartTime()));
+        }
+
+        if (!empty($processResultEntityTransfer->getEndTime())) {
+            $processResultTransfer->setEndTime(strtotime($processResultEntityTransfer->getEndTime()));
+        }
 
         $processResultTransfer = $this->mapArrayToStagesResult($processResultTransfer, $this->utilEncoding->decodeJson($processResultEntityTransfer->getStageResults(), true));
 

--- a/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
+++ b/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
@@ -41,8 +41,11 @@ class ProcessResultMapper
         $processResultEntityTransfer->setFailedItemCount($processResultTransfer->getFailedItemCount());
         $processResultEntityTransfer->setSkippedItemCount($processResultTransfer->getSkippedItemCount());
         $processResultEntityTransfer->setItemCount($processResultTransfer->getItemCount());
-        $processResultEntityTransfer->setStartTime($processResultTransfer->getStartTime());
-        $processResultEntityTransfer->setEndTime($processResultTransfer->getEndTime());
+
+        $startTime = $processResultTransfer->getStartTime() ? date('Y-m-d H:i:s', $processResultTransfer->getStartTime()) : null;
+        $processResultEntityTransfer->setStartTime($startTime);
+        $endTime = $processResultTransfer->getEndTime() ? date('Y-m-d H:i:s', $processResultTransfer->getEndTime()) : null;
+        $processResultEntityTransfer->setEndTime($endTime);
 
         $stagesResults = $this->mapStagesResultToArray($processResultTransfer->getStageResults());
         $processResultEntityTransfer->setStageResults($this->utilEncoding->encodeJson($stagesResults));
@@ -64,8 +67,8 @@ class ProcessResultMapper
         $processResultTransfer->setFailedItemCount($processResultEntityTransfer->getFailedItemCount());
         $processResultTransfer->setSkippedItemCount($processResultEntityTransfer->getSkippedItemCount());
         $processResultTransfer->setItemCount($processResultEntityTransfer->getItemCount());
-        $processResultTransfer->setStartTime($processResultEntityTransfer->getStartTime());
-        $processResultTransfer->setEndTime($processResultEntityTransfer->getEndTime());
+        $processResultTransfer->setStartTime(strtotime($processResultEntityTransfer->getStartTime()));
+        $processResultTransfer->setEndTime(strtotime($processResultEntityTransfer->getEndTime()));
 
         $processResultTransfer = $this->mapArrayToStagesResult($processResultTransfer, $this->utilEncoding->decodeJson($processResultEntityTransfer->getStageResults(), true));
 

--- a/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
+++ b/src/SprykerMiddleware/Zed/Report/Persistence/Mapper/ProcessResultMapper.php
@@ -42,12 +42,12 @@ class ProcessResultMapper
         $processResultEntityTransfer->setSkippedItemCount($processResultTransfer->getSkippedItemCount());
         $processResultEntityTransfer->setItemCount($processResultTransfer->getItemCount());
 
-        $startTime = !empty($processResultTransfer->getStartTime())
+        $startTime = ($processResultTransfer->getStartTime() !== null)
             ? date('Y-m-d H:i:s', $processResultTransfer->getStartTime())
             : null;
         $processResultEntityTransfer->setStartTime($startTime);
 
-        $endTime = !empty($processResultTransfer->getEndTime())
+        $endTime = ($processResultTransfer->getEndTime() !== null)
             ? date('Y-m-d H:i:s', $processResultTransfer->getEndTime())
             : null;
         $processResultEntityTransfer->setEndTime($endTime);
@@ -73,11 +73,11 @@ class ProcessResultMapper
         $processResultTransfer->setSkippedItemCount($processResultEntityTransfer->getSkippedItemCount());
         $processResultTransfer->setItemCount($processResultEntityTransfer->getItemCount());
 
-        if (!empty($processResultEntityTransfer->getStartTime())) {
+        if ($processResultEntityTransfer->getStartTime() !== null) {
             $processResultTransfer->setStartTime(strtotime($processResultEntityTransfer->getStartTime()));
         }
 
-        if (!empty($processResultEntityTransfer->getEndTime())) {
+        if ($processResultEntityTransfer->getEndTime() !== null) {
             $processResultTransfer->setEndTime(strtotime($processResultEntityTransfer->getEndTime()));
         }
 


### PR DESCRIPTION
The types are wrong when mapping from the entity to the transfers. 

You can clearly see why this can be a problem by looking at the code below:

```php
ProcessResultTransfer::getStartTime(): ?int # Expected to be a unix type
// VS
SpyProcessResultEntityTransfer::getStartTime(): ?string # Expected to be a string date time
```